### PR TITLE
Fix failing assertion when compiling with swift-wasm-5.9 snapshot

### DIFF
--- a/Sources/WebWorkerKit/WebWorkerMessage.swift
+++ b/Sources/WebWorkerKit/WebWorkerMessage.swift
@@ -66,12 +66,13 @@ enum WebWorkerMessage: ConvertibleToJSValue {
         let encoder = JSValueEncoder()
         switch self {
         case .remoteCall(let callEnvelope):
+            let recipient = try? encoder.encode(callEnvelope.recipient)
             let callEnvelope = [
                 "callID": callEnvelope.callID,
                 "genericSubs": callEnvelope.genericSubs,
                 "invocationTarget": callEnvelope.invocationTarget,
                 "args": callEnvelope.args,
-                "recipient": try? encoder.encode(callEnvelope.recipient)
+                "recipient": recipient
             ].jsValue
 
             return ["remoteCall", callEnvelope].jsValue
@@ -80,9 +81,10 @@ enum WebWorkerMessage: ConvertibleToJSValue {
             return ["processReady"].jsValue
 
         case .reply(let payload):
+            let sender = try? encoder.encode(payload.sender)
             let replyEnvelope = [
                 "callID": payload.callID,
-                "sender": try? encoder.encode(payload.sender),
+                "sender": sender,
                 "value": payload.value
             ].jsValue
 


### PR DESCRIPTION
Fixes following build issue which occured with XCode 15 and the swift-wasm-5.9 developer snapshot:

```
Building for debugging...
Assertion failed: (!concreteBuffer && "concrete buffer already formed?!"), function getAddressForInPlaceInitialization, file SILGenConvert.cpp, line 564.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.      Program arguments: /Library/Developer/Toolchains/swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a.xctoolchain/usr/bin/swift-frontend -frontend -c Packages/WebWorkerKit/Sources/WebWorkerKit/JSValueEncoder.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorker.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerActorSystem+remoteCall.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerActorSystem.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerCallDecoder.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerCallEncoder.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerHost.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerIdentity.swift -primary-file Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerMessage.swift Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerResultHandler.swift -emit-module-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage~partial.swiftmodule -emit-module-doc-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage~partial.swiftdoc -emit-module-source-info-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage~partial.swiftsourceinfo -emit-dependencies-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage.d -emit-reference-dependencies-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage.swiftdeps -target wasm32-unknown-wasi -disable-objc-interop -sdk /Library/Developer/Toolchains/swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a.xctoolchain/usr/share/wasi-sysroot -I Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -color-diagnostics -enable-testing -g -module-cache-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/ModuleCache -swift-version 5 -Onone -D SWIFT_PACKAGE -D DEBUG -enable-anonymous-context-mangled-names -plugin-path /Library/Developer/Toolchains/swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Library/Developer/Toolchains/swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a.xctoolchain/usr/local/lib/swift/host/plugins -Xcc -fmodule-map-file=Packages/WebWorkerKit/.build/checkouts/JavaScriptKit/Sources/_CJavaScriptEventLoop/include/module.modulemap -Xcc -I -Xcc Packages/WebWorkerKit/.build/checkouts/JavaScriptKit/Sources/_CJavaScriptEventLoop/include -Xcc -fmodule-map-file=Packages/WebWorkerKit/.build/checkouts/JavaScriptKit/Sources/_CJavaScriptKit/include/module.modulemap -Xcc -I -Xcc Packages/WebWorkerKit/.build/checkouts/JavaScriptKit/Sources/_CJavaScriptKit/include -Xcc --sysroot -Xcc /Library/Developer/Toolchains/swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a.xctoolchain/usr/share/wasi-sysroot -Xcc -F -Xcc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -Xcc -fPIC -Xcc -g -parse-as-library -module-name WebWorkerKit -o Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/WebWorkerKit.build/WebWorkerMessage.swift.o -index-store-path Packages/WebWorkerKit/.build/wasm32-unknown-wasi/debug/index/store -index-system-modules -use-static-resource-dir
1.      SwiftWasm Swift version 5.9-dev (LLVM 880cf58f10f5f0a, Swift 87da88c03ec9ccf)
2.      Compiling with the current language version
3.      While evaluating request ASTLoweringRequest(Lowering AST to SIL for file "Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerMessage.swift")
4.      While silgen emitFunction SIL function "@$s12WebWorkerKit0aB7MessageO7jsValue010JavaScriptC07JSValueOvg".
 for getter for jsValue (at Packages/WebWorkerKit/Sources/WebWorkerKit/WebWorkerMessage.swift:65:9)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x0000000109b37aa0 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x0000000109b36c38 llvm::sys::RunSignalHandlers() + 112
2  swift-frontend           0x0000000109b3812c SignalHandler(int) + 344
3  libsystem_platform.dylib 0x00000001a25fea24 _sigtramp + 56
4  libsystem_pthread.dylib  0x00000001a25cfc28 pthread_kill + 288
5  libsystem_c.dylib        0x00000001a24ddae8 abort + 180
6  libsystem_c.dylib        0x00000001a24dce44 err + 0
7  swift-frontend           0x0000000109c34138 swift::Lowering::ManagedValue llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SGFContext)>::callback_fn<swift::Lowering::SILGenFunction::emitExistentialErasure(swift::SILLocation, swift::CanType, swift::Lowering::TypeLowering const&, swift::Lowering::TypeLowering const&, llvm::ArrayRef<swift::ProtocolConformanceRef>, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SGFContext)>, bool)::$_5>(long, swift::Lowering::SGFContext) (.cold.1) + 0
8  swift-frontend           0x000000010558f778 (anonymous namespace)::ExistentialInitialization::getAddressForInPlaceInitialization(swift::Lowering::SILGenFunction&, swift::SILLocation) + 792
9  swift-frontend           0x00000001055b1798 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) + 18880
10 swift-frontend           0x00000001055a5580 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) + 56
11 swift-frontend           0x00000001055bbda0 swift::Lowering::ManagedValue llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SGFContext)>::callback_fn<(anonymous namespace)::RValueEmitter::visitErasureExpr(swift::ErasureExpr*, swift::Lowering::SGFContext)::$_10>(long, swift::Lowering::SGFContext) + 68
12 swift-frontend           0x000000010558f8fc void llvm::function_ref<void (swift::SILValue)>::callback_fn<swift::Lowering::SILGenFunction::emitExistentialErasure(swift::SILLocation, swift::CanType, swift::Lowering::TypeLowering const&, swift::Lowering::TypeLowering const&, llvm::ArrayRef<swift::ProtocolConformanceRef>, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SGFContext)>, bool)::$_6>(long, swift::SILValue) + 140
13 swift-frontend           0x0000000105578b04 swift::Lowering::SILGenBuilder::bufferForExpr(swift::SILLocation, swift::SILType, swift::Lowering::TypeLowering const&, swift::Lowering::SGFContext, llvm::function_ref<void (swift::SILValue)>) + 136
14 swift-frontend           0x000000010558c304 swift::Lowering::SILGenFunction::emitExistentialErasure(swift::SILLocation, swift::CanType, swift::Lowering::TypeLowering const&, swift::Lowering::TypeLowering const&, llvm::ArrayRef<swift::ProtocolConformanceRef>, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SGFContext)>, bool) + 1052
15 swift-frontend           0x00000001055af4e8 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) + 10000
16 swift-frontend           0x00000001055a3308 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, llvm::Optional<swift::SILLocation>) + 232
17 swift-frontend           0x00000001055b6b88 (anonymous namespace)::RValueEmitter::visitTupleExpr(swift::TupleExpr*, swift::Lowering::SGFContext) + 396
18 swift-frontend           0x00000001055a3308 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, llvm::Optional<swift::SILLocation>) + 232
19 swift-frontend           0x00000001055317ec swift::Lowering::ArgumentSource::forwardInto(swift::Lowering::SILGenFunction&, swift::Lowering::Initialization*) && + 164
20 swift-frontend           0x0000000105531d48 swift::Lowering::ArgumentSource::forwardInto(swift::Lowering::SILGenFunction&, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*, swift::Lowering::TypeLowering const&) && + 256
21 swift-frontend           0x00000001055b9c5c (anonymous namespace)::RValueEmitter::visitCollectionExpr(swift::CollectionExpr*, swift::Lowering::SGFContext) + 936
22 swift-frontend           0x00000001055a5580 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) + 56
23 swift-frontend           0x00000001055d2d8c SILGenLValue::visitRec(swift::Expr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions, swift::Lowering::AbstractionPattern) + 1192
24 swift-frontend           0x00000001055d5b48 SILGenLValue::visitMemberRefExpr(swift::MemberRefExpr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions) + 668
25 swift-frontend           0x00000001055d2368 swift::Lowering::SILGenFunction::emitLValue(swift::Expr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions) + 56
26 swift-frontend           0x00000001055afaac swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) + 11476
27 swift-frontend           0x00000001055a3308 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, llvm::Optional<swift::SILLocation>) + 232
28 swift-frontend           0x0000000105591f94 swift::Lowering::SILGenFunction::emitPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) + 1372
29 swift-frontend           0x00000001055921b0 swift::Lowering::SILGenFunction::visitPatternBindingDecl(swift::PatternBindingDecl*, bool) + 64
30 swift-frontend           0x0000000105616e10 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) + 3884
31 swift-frontend           0x0000000105615ed8 swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) + 24
32 swift-frontend           0x00000001055f4fd0 (anonymous namespace)::PatternMatchEmission::emitCaseBody(swift::CaseStmt*) + 40
33 swift-frontend           0x00000001055f5788 void llvm::function_ref<void ((anonymous namespace)::PatternMatchEmission&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, (anonymous namespace)::ClauseRow&)>::callback_fn<swift::Lowering::SILGenFunction::emitSwitchStmt(swift::SwitchStmt*)::$_0>(long, (anonymous namespace)::PatternMatchEmission&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, (anonymous namespace)::ClauseRow&) + 1788
34 swift-frontend           0x00000001055ec550 (anonymous namespace)::PatternMatchEmission::emitDispatch((anonymous namespace)::ClauseMatrix&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, std::__1::function<void (swift::SILLocation)> const&) + 1892
35 swift-frontend           0x00000001055f1f10 std::__1::__function::__func<(anonymous namespace)::PatternMatchEmission::emitSpecializedDispatch((anonymous namespace)::ClauseMatrix&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, unsigned int&, unsigned int, std::__1::function<void (swift::SILLocation)> const&)::$_10, std::__1::allocator<(anonymous namespace)::PatternMatchEmission::emitSpecializedDispatch((anonymous namespace)::ClauseMatrix&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, unsigned int&, unsigned int, std::__1::function<void (swift::SILLocation)> const&)::$_10>, void (llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, llvm::ArrayRef<(anonymous namespace)::SpecializedRow>, std::__1::function<void (swift::SILLocation)> const&)>::operator()(llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>&&, llvm::ArrayRef<(anonymous namespace)::SpecializedRow>&&, std::__1::function<void (swift::SILLocation)> const&) + 1320
36 swift-frontend           0x00000001055f39d8 (anonymous namespace)::PatternMatchEmission::emitEnumElementObjectDispatch(llvm::ArrayRef<(anonymous namespace)::RowToSpecialize>, swift::Lowering::ConsumableManagedValue, std::__1::function<void (llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, llvm::ArrayRef<(anonymous namespace)::SpecializedRow>, std::__1::function<void (swift::SILLocation)> const&)> const&, std::__1::function<void (swift::SILLocation)> const&, swift::ProfileCounter)::$_17::operator()(swift::EnumElementDecl*, swift::SILBasicBlock*, (anonymous namespace)::CaseInfo const&) const + 1248
37 swift-frontend           0x00000001055efa9c (anonymous namespace)::PatternMatchEmission::emitSpecializedDispatch((anonymous namespace)::ClauseMatrix&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, unsigned int&, unsigned int, std::__1::function<void (swift::SILLocation)> const&) + 3020
38 swift-frontend           0x00000001055ec0e8 (anonymous namespace)::PatternMatchEmission::emitDispatch((anonymous namespace)::ClauseMatrix&, llvm::ArrayRef<swift::Lowering::ConsumableManagedValue>, std::__1::function<void (swift::SILLocation)> const&) + 764
39 swift-frontend           0x00000001055eb760 swift::Lowering::SILGenFunction::emitSwitchStmt(swift::SwitchStmt*) + 3392
40 swift-frontend           0x0000000105616f34 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) + 4176
41 swift-frontend           0x0000000105615ed8 swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) + 24
42 swift-frontend           0x00000001055c4548 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) + 392
43 swift-frontend           0x00000001055476d4 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) + 9020
44 swift-frontend           0x000000010554813c swift::Lowering::SILGenModule::emitOrDelayFunction(swift::SILDeclRef) + 200
45 swift-frontend           0x0000000105545380 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) + 164
46 swift-frontend           0x00000001056240a0 (anonymous namespace)::SILGenType::visitFuncDecl(swift::FuncDecl*) + 28
47 swift-frontend           0x00000001063a8c68 swift::AbstractStorageDecl::visitEmittedAccessors(llvm::function_ref<void (swift::AccessorDecl*)>) const + 104
48 swift-frontend           0x0000000105624064 (anonymous namespace)::SILGenType::visitVarDecl(swift::VarDecl*) + 384
49 swift-frontend           0x0000000105621048 (anonymous namespace)::SILGenType::emitType() + 120
50 swift-frontend           0x0000000105620fc4 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) + 24
51 swift-frontend           0x000000010554ab88 swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const + 988
52 swift-frontend           0x00000001056159bc swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)9>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) + 132
53 swift-frontend           0x000000010554e710 llvm::Expected<swift::ASTLoweringRequest::OutputType> swift::Evaluator::getResultUncached<swift::ASTLoweringRequest>(swift::ASTLoweringRequest const&) + 380
54 swift-frontend           0x000000010554bdf4 swift::performASTLowering(swift::FileUnit&, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) + 80
55 swift-frontend           0x0000000104fed190 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 552
56 swift-frontend           0x0000000104ffc288 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) + 160
57 swift-frontend           0x0000000104fefc5c performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 724
58 swift-frontend           0x0000000104feec10 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2440
59 swift-frontend           0x0000000104e2b50c swift::mainEntry(int, char const**) + 2140
60 dyld                     0x00000001a2277f28 start + 2236

```

