### PR TITLE
Bump minimum versions for macOS to 10.15 and iOS to 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,10 @@ import PackageDescription
 
 let package = Package(
     name: "WebWorkerKit",
+    platforms: [
+        .macOS("10.15"),
+        .iOS(.v13),
+    ],
     products: [
         .library(
             name: "WebWorkerKit",

--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "WebWorkerKit",
-    platforms: [
-        .macOS("10.15"),
-        .iOS(.v13),
-    ],
+    platforms: [.macOS(.v10_15), .iOS(.v13)],
     products: [
         .library(
             name: "WebWorkerKit",


### PR DESCRIPTION
This fixes the issue where we get a version mismatch when building since the new version of JavaScriptKit needs macOS 10.15 and WebWorkerKit requires macOS 10.13 (since we did not specify a minimum version before).